### PR TITLE
Allow configuring the http client that's used

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -55,6 +55,7 @@ type Client struct {
 	queueSize     int
 	interval      time.Duration
 	onPublishFunc func(status int, err error)
+	httpClient    *http.Client
 }
 
 func New(apiKey string, options ...Option) *Client {
@@ -69,6 +70,7 @@ func New(apiKey string, options ...Option) *Client {
 		queueSize:     DefaultQueueSize,
 		interval:      time.Second * 15,
 		onPublishFunc: func(status int, err error) {},
+		httpClient:    http.DefaultClient,
 	}
 
 	for _, opt := range options {
@@ -156,7 +158,7 @@ func (c *Client) publish(events []Event) error {
 	params.Set("event", string(data))
 
 	ctx, _ := context.WithTimeout(context.Background(), time.Second*10)
-	resp, err := ctxhttp.PostForm(ctx, http.DefaultClient, ApiEndpoint, params)
+	resp, err := ctxhttp.PostForm(ctx, c.httpClient, ApiEndpoint, params)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/options.go
+++ b/options.go
@@ -1,6 +1,9 @@
 package amplitude
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 type Option func(*Client)
 
@@ -13,5 +16,11 @@ func Interval(v time.Duration) Option {
 func OnPublishFunc(fn func(status int, err error)) Option {
 	return func(c *Client) {
 		c.onPublishFunc = fn
+	}
+}
+
+func HTTPClient(httpClient *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = httpClient
 	}
 }


### PR DESCRIPTION
We want this at Superhuman in order to stub out all network activity
during tests, and to add instrumentation to all outbound API calls.